### PR TITLE
Add support for Xcode 13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,11 @@ on:
   pull_request: {}
 jobs:
   run:
-    runs-on: macOS-latest
+    runs-on: macos-11
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["12.2"]
+        xcode: ["13.0"]
     steps:
     - uses: actions/checkout@master
     - name: Set Xcode

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "df4d5b3ec2c1421a58d71010ff43528db5b19e04",
-          "version": "5.3.3"
+          "revision": "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+          "version": "6.0.3"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams", from: "1.0.0"),
-        .package(url: "https://github.com/kylef/PathKit", from: "0.9.0"),
+        .package(url: "https://github.com/kylef/PathKit", from: "1.0.1"),
         .package(url: "https://github.com/onevcat/Rainbow", from: "3.1.0"),
         .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.2.0"),
         .package(url: "https://github.com/dduan/TOMLDeserializer", from: "0.2.4"),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/Yams", from: "1.0.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.1"),
         .package(url: "https://github.com/onevcat/Rainbow", from: "3.1.0"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.2.0"),
+        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.3"),
         .package(url: "https://github.com/dduan/TOMLDeserializer", from: "0.2.4"),
         .package(url: "https://github.com/yonaskolb/Codability", from: "0.2.1"),
     ],

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ stringly generate-file Strings.yml Strings.strings --language de
 
 ## Installing
 
-Make sure Xcode 11 is installed first.
+Make sure Xcode 13 is installed first.
 
 ### [Mint](https://github.com/yonaskolb/mint)
 ```sh

--- a/Sources/StringlyCLI/CLI.swift
+++ b/Sources/StringlyCLI/CLI.swift
@@ -31,7 +31,7 @@ public class StringlyCLI {
 }
 
 extension Path: ConvertibleFromString {
-    public static func convert(from: String) -> Path? {
-        Path(from)
+    public init?(input: String) {
+        self.init(input)
     }
 }

--- a/Sources/StringlyCLI/Commands/GenerateCommand.swift
+++ b/Sources/StringlyCLI/Commands/GenerateCommand.swift
@@ -17,12 +17,13 @@ class GenerateCommand: Command {
     let shortDescription: String = "Generates all required localization files for a given platform"
     let platform = Key<PlatformType>("--platform", "-p", description: "The platform to generate files for. Defaults to apple")
 
-    let sourcePath = Param.Required<Path>()
+    @Param
+    var sourcePath: Path
     let directoryPath = Key<Path>("--directory", "-d", description: "The directory to generate the files in. Defaults to the directory the source path is in")
     let baseLanguage = Key<String>("--base", "-b", description: "The base language to use. Defaults to en")
 
     func execute() throws {
-        let sourcePath = self.sourcePath.value.normalize()
+        let sourcePath = self.sourcePath.normalize()
         let directoryPath = self.directoryPath.value ?? sourcePath.parent()
         let baseLanguage = self.baseLanguage.value ?? "en"
         let platform = self.platform.value ?? .apple

--- a/Sources/StringlyCLI/Commands/GenerateFileCommand.swift
+++ b/Sources/StringlyCLI/Commands/GenerateFileCommand.swift
@@ -26,12 +26,14 @@ class GenerateFileCommand: Command {
 
     let type = Key<FileType>("--type", "-t", description: "The file type to generate. Defaults to inferring from the destination file extension")
 
-    let sourcePath = Param.Required<Path>()
-    let destinationPath = Param.Optional<Path>()
+    @Param
+    var sourcePath: Path
+    @Param
+    var destinationPath: Path?
 
     func execute() throws {
-        let sourcePath = self.sourcePath.value.normalize()
-        let destinationPath = self.destinationPath.value?.normalize()
+        let sourcePath = self.sourcePath.normalize()
+        let destinationPath = self.destinationPath?.normalize()
         let language = self.language.value ?? "en"
         let baseLanguage = self.baseLanguage.value ?? "en"
 


### PR DESCRIPTION
## Overview

- Updates `PathKit`, `Spectre` & `SwiftCLI` to the latest Xcode 13 supporting versions
- Updates `SwiftCLI` usage within Stringly to support the new API